### PR TITLE
http: convert content-length header to upper cases

### DIFF
--- a/cores/esp8266/WString.cpp
+++ b/cores/esp8266/WString.cpp
@@ -490,6 +490,12 @@ unsigned char String::startsWith(const String &s2, unsigned int offset) const {
     return strncmp(&buffer[offset], s2.buffer, s2.len) == 0;
 }
 
+unsigned char String::startsWithIgnoreCase(const String &s2) const {
+  if (len < s2.len)
+    return 0;
+  return substring(0, s2.len).equalsIgnoreCase(s2);
+}
+
 unsigned char String::endsWith(const String &s2) const {
     if(len < s2.len || !buffer || !s2.buffer)
         return 0;

--- a/cores/esp8266/WString.h
+++ b/cores/esp8266/WString.h
@@ -196,6 +196,7 @@ class String {
         unsigned char equalsIgnoreCase(const String &s) const;
         unsigned char startsWith(const String &prefix) const;
         unsigned char startsWith(const String &prefix, unsigned int offset) const;
+        unsigned char startsWithIgnoreCase(const String &prefix) const;
         unsigned char endsWith(const String &suffix) const;
 
         // character acccess

--- a/src/http.cpp
+++ b/src/http.cpp
@@ -79,7 +79,7 @@ ferr_t do_http_request(const char *host, int port, const char *method,
         if (l.equals("\r"))
             break;
 
-        if (l.startsWith("Content-Length:")) {
+        if (l.startsWithIgnoreCase("Content-Length:")) {
             content_length = atol(l.c_str() + l.indexOf(' ') + 1);
         }
     }


### PR DESCRIPTION
For example, the webpack-dev-server returns the `Content-Length` header as `content-length`.